### PR TITLE
fix: run WorkspaceService PSCommands on the pipeline thread

### DIFF
--- a/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
+++ b/src/PowerShellEditorServices/Services/PowerShell/Host/PsesInternalHost.cs
@@ -226,6 +226,8 @@ namespace Microsoft.PowerShell.EditorServices.Services.PowerShell.Host
 
         public bool IsRunning => _isRunningLatch.IsSignaled;
 
+        internal bool IsPipelineThread => Environment.CurrentManagedThreadId == _pipelineThread.ManagedThreadId;
+
         public Task Shutdown => _stopped.Task;
 
         IRunspaceInfo IRunspaceContext.CurrentRunspace => CurrentRunspace;

--- a/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
+++ b/src/PowerShellEditorServices/Services/Workspace/WorkspaceService.cs
@@ -447,7 +447,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
                         .AddParameter("EQ")
                         .AddParameter("Value", false);
 
-                IReadOnlyList<PSObject> results = psesInternalHost.InvokePSCommand<PSObject>(psCommand, null, CancellationToken.None);
+                IReadOnlyList<PSObject> results = ExecutePSCommandOnPipelineThread<PSObject>(psCommand, null, CancellationToken.None);
                 foreach (string path in results.Select(ConvertWorkspaceItemPath).Where(path => !string.IsNullOrEmpty(path)))
                 {
                     yield return path;
@@ -510,7 +510,7 @@ namespace Microsoft.PowerShell.EditorServices.Services
             string psPath = GetPowerShellPath(uri);
             try
             {
-                IReadOnlyList<string> result = psesInternalHost.InvokePSCommand<string>(
+                IReadOnlyList<string> result = ExecutePSCommandOnPipelineThread<string>(
                     new PSCommand()
                         .AddCommand(@"Microsoft.PowerShell.Management\Get-Content")
                             .AddParameter("LiteralPath", psPath)
@@ -521,12 +521,30 @@ namespace Microsoft.PowerShell.EditorServices.Services
                 return string.Join(Environment.NewLine, result);
             }
             catch (ActionPreferenceStopException ex)
-                when (ex.ErrorRecord.CategoryInfo.Category == ErrorCategory.ObjectNotFound
-                    && ex.ErrorRecord.TargetObject is string[] missingFiles
-                    && missingFiles.Length == 1)
+                when (ex.ErrorRecord.CategoryInfo.Category == ErrorCategory.ObjectNotFound)
             {
-                throw new FileNotFoundException(ex.ErrorRecord.ToString(), missingFiles[0], ex.ErrorRecord.Exception);
+                // The FileSystem provider reports missing paths as string[]; other providers use a plain string.
+                string missingFile = ex.ErrorRecord.TargetObject switch
+                {
+                    string[] { Length: 1 } missingFiles => missingFiles[0],
+                    string missingPath => missingPath,
+                    _ => psPath,
+                };
+
+                throw new FileNotFoundException(ex.ErrorRecord.ToString(), missingFile, ex.ErrorRecord.Exception);
             }
+        }
+
+        // InvokePSCommand is only safe on the pipeline thread; queue onto it unless already there.
+        private IReadOnlyList<TResult> ExecutePSCommandOnPipelineThread<TResult>(
+            PSCommand psCommand,
+            PowerShellExecutionOptions executionOptions,
+            CancellationToken cancellationToken)
+        {
+            return psesInternalHost.IsPipelineThread
+                ? psesInternalHost.InvokePSCommand<TResult>(psCommand, executionOptions, cancellationToken)
+                : psesInternalHost.ExecutePSCommandAsync<TResult>(psCommand, cancellationToken, executionOptions)
+                    .GetAwaiter().GetResult();
         }
 
         // Return only file-backed workspace roots as filesystem paths.


### PR DESCRIPTION
## Summary

- `InvokePSCommand` executes on the calling thread against the shared runspace, so calling it from LSP handler threads violated runspace thread affinity. `EnumeratePSFiles` and `GetContent` in `WorkspaceService` now route through a new `ExecutePSCommandOnPipelineThread` helper that queues onto the pipeline thread via `ExecutePSCommandAsync` unless the caller is already on it (guarded by a new internal `PsesInternalHost.IsPipelineThread` property, which prevents self-deadlock when blocking on the queued task).
- Broadens the `ObjectNotFound` catch in `GetContent`: the FileSystem provider reports missing paths as `string[]`, but other providers report a plain `string`, so their misses previously leaked out as raw `ActionPreferenceStopException` instead of `FileNotFoundException`.

## Why

Needed for PSPath-backed script files in ImmyBot (feat/pspath-script-provider). Reading workspace files through a custom PSProvider from LSP request threads intermittently corrupted the runspace due to the thread-affinity violation. Once merged, ImmyBot bumps the editor services package to preview.6 built from `feature/get-content-host-package`.

## Testing

Verified against a live ImmyBot session: PSPath-backed files load through `GetContent` from LSP handler threads without runspace errors, and missing PSPath files surface as `FileNotFoundException` matching FileSystem behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)